### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+CHANGELOG.md
+LICENSE.txt
+README.md


### PR DESCRIPTION
Hey-lo,

I'm building a version of `weightedcalcs` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

This pull should add a `MANIFEST.in` that guarantees the license gets included, along with the change log and the Readme.